### PR TITLE
Add flag to download only Read-Only (attribute 33) files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ENV ADDRESS="" \
     CRON=1 \
     DRY_RUN="" \
     RUN_ONCE="" \
+    READ_ONLY="" \
     GPS_EXTRACT=""
 
 COPY --chown=dashcam viofosync.sh /viofosync.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,9 @@ services:
       # assumed.
       KEEP: 2w
 
+      # Store and manage Read Only (locked) video recordings.
+      READ_ONLY: false
+
       # Stops downloading if the amount of used disk space exceeds the indicated
       # percentage value.
       MAX_USED_DISK: 90

--- a/viofosync.py
+++ b/viofosync.py
@@ -121,6 +121,9 @@ def get_dashcam_filenames(base_url):
         
         recordings = []
         for file_elem in root.findall(".//File"):
+            attr = int(file_elem.find("ATTR").text)
+            if read_only and attr != 33:
+                continue
             name = file_elem.find("NAME").text
             filepath = file_elem.find("FPATH").text
             size = int(file_elem.find("SIZE").text)
@@ -544,6 +547,7 @@ def parse_args():
     parser.add_argument("-v", "--verbose", action="count", default=0, help="Increase output verbosity")
     parser.add_argument("-q", "--quiet", action="store_true", help="Quiets down output messages; overrides verbosity options")
     parser.add_argument("--dry-run", action="store_true", help="Perform a trial run without downloading files")
+    parser.add_argument("--read-only", action="store_true", help="Store and manage Read Only (locked) video recordings")
     parser.add_argument("--cron", action="store_true", help="cron mode, only logs normal recordings at default verbosity")
     parser.add_argument("--gps-extract", action="store_true", help="Extract GPS data and create GPX files")
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
@@ -551,7 +555,7 @@ def parse_args():
 
 def run():
     """run forrest run"""
-    global dry_run, max_disk_used_percent, cutoff_date, socket_timeout
+    global dry_run, read_only, max_disk_used_percent, cutoff_date, socket_timeout
 
     args = parse_args()
 
@@ -570,6 +574,10 @@ def run():
     dry_run = args.dry_run
     if dry_run:
         logger.info("DRY RUN No action will be taken.")
+
+    read_only = args.read_only
+    if read_only:
+        logger.info("READ ONLY files will be managed.")
 
     if args.keep:
         keep_match = re.fullmatch(r"(?P<range>\d+)(?P<unit>[dw]?)", args.keep)

--- a/viofosync.sh
+++ b/viofosync.sh
@@ -21,6 +21,9 @@ verbose=${VERBOSE:+$(if [[ $VERBOSE -gt 0 ]]; then for i in $(seq 1 $VERBOSE); d
 # dry-run option if DRY_RUN set to anything
 quiet="${QUIET:+--quiet}"
 
+# read_only option if READ_ONLY set to anything
+read_only="${READ_ONLY:+--read-only}"
+
 # cron option if CRON set to anything
 cron="${CRON:+--cron}"
 
@@ -30,4 +33,4 @@ dry_run="${DRY_RUN:+--dry-run}"
 gps_extract="${GPS_EXTRACT:+--gps-extract}"
 
 /viofosync.py ${ADDRESS} --destination /recordings ${keep} ${grouping} ${priority} ${disk_usage} ${timeout} ${verbose} ${gps_extract} \
-    ${quiet} ${cron} ${dry_run}
+    ${quiet} ${read_only} ${cron} ${dry_run}


### PR DESCRIPTION
# Add flag to download only Read-Only (attribute 33) files

This pull request introduces a new feature to ViofoSync that allows users to download **only files marked as Read-Only (attribute 33)** from the dashcam.

## Changes included

1. **New command-line flag**  
   - Added `--read-only` to enable selective downloading of Read-Only files only.

2. **Modified Recordings function**  
   - Implemented a check to filter files based on their attribute, ensuring only Read-Only files are downloaded when the flag is used.

3. **Integration with existing workflow**  
   - Works alongside existing download options without affecting default behaviour.

## Benefits

- Prevents downloading unnecessary non-protected files.  
- Useful for selectively backing up important dashcam footage.  
- Minimal impact on existing functionality; default behaviour remains unchanged if the flag is not used.

## Testing

- Verified that only Read-Only files are downloaded when the flag is active.  
- Confirmed that all files are downloaded normally when the flag is not provided.

## Notes

- No new dependencies were introduced.  
- Fully backwards-compatible with current workflows.
