### PR TITLE
Migrate db and fix retention sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,50 @@
 # Changelog
 
+## v2.1 — 2026-05-16
+
+### Fixed
+
+- DB now lives in the `/config` volume rather than the recordings  
+mount for better performance when the recordings are on  
+slower storage.
+- The startup retention sweep runs in the background rather than  
+blocking the UI when there's a large delete backlog.
+
+### Changed
+
+- Retention sweep logs progress: a header when the time-phase has  
+work, then a line every 10 deletions. Previously silent until the  
+end-of-sweep summary.
+
+### Migration
+
+- An existing DB at `${RECORDINGS}/.viofosync.db` is copied to  
+`${CONFIG_DIR}/viofosync.db` on first boot under v2.1. The legacy  
+file is renamed to `.viofosync.db.migrated` on the recordings  
+volume as a recoverable fallback.
+
 ## v2.0 — 2026-05
 
 Major rewrite. Web UI replaces the cron CLI.
 
 ### Added
-- Web UI on port 8080 with archive browser, download manager, GPX
-  journey map, and ffmpeg picture-in-picture exports.
+
+- Web UI on port 8080 with archive browser, download manager, GPX  
+journey map, and ffmpeg picture-in-picture exports.
 - First-run setup wizard at `/setup`.
-- Settings page (UI-driven config, hot-reloaded for runtime values,
-  restart-required for `WEB_HOST`/`WEB_PORT`).
+- Settings page (UI-driven config, hot-reloaded for runtime values,  
+restart-required for `WEB_HOST`/`WEB_PORT`).
 - JSON config at `/config/config.json` replaces `viofosync.env`.
 
 ### Changed
+
 - Docker image is webapp-only; cron CLI is no longer the primary path.
 - Required env vars reduced to `PUID` / `PGID` / `TZ`.
 
 ### Migration
-- Existing `viofosync.env` files are migrated to `config.json` on first
-  boot. The old file is preserved as a one-shot rollback path.
+
+- Existing `viofosync.env` files are migrated to `config.json` on first  
+boot. The old file is preserved as a one-shot rollback path.
 
 ## v1.x
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       # Config directory. A template viofosync.env is seeded here on first
       # run — edit it (ADDRESS, WEB_PASSWORD, etc.) and restart to apply.
       - /path/to/config:/config
-      # Recordings + SQLite state DB. Change only the part before the colon.
+      # Recordings (dashcam archive). The state DB lives in /config, not here.
       - /path/to/recordings:/recordings:rw
 
     environment:

--- a/tests/test_db_migration.py
+++ b/tests/test_db_migration.py
@@ -1,0 +1,165 @@
+"""Tests for the one-shot legacy-DB migration helper."""
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+
+from web.db import Database, migrate_legacy_db_path
+
+
+def _seed_legacy_db(path: Path) -> None:
+    """Write a sentinel row into a SQLite file at `path` so we can
+    confirm the migrated DB carries the same data."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    c = sqlite3.connect(str(path))
+    c.execute("CREATE TABLE kv (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+    c.execute("INSERT INTO kv (key, value) VALUES ('marker', 'legacy-data')")
+    c.commit()
+    c.close()
+
+
+def test_migrate_copies_legacy_db_and_renames_source(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """When legacy DB exists and new path is empty, migrate copies the
+    DB across, renames the legacy file to .viofosync.db.migrated, and
+    the migrated DB returns the original row."""
+    rec = tmp_path / "rec"
+    cfg = tmp_path / "cfg"
+    rec.mkdir()
+    monkeypatch.setenv("RECORDINGS", str(rec))
+
+    legacy = rec / ".viofosync.db"
+    _seed_legacy_db(legacy)
+
+    new_path = str(cfg / "viofosync.db")
+    migrate_legacy_db_path(new_path)
+
+    assert Path(new_path).exists(), "new DB should exist after migration"
+    assert not legacy.exists(), "legacy file should be renamed"
+    assert (rec / ".viofosync.db.migrated").exists(), \
+        "legacy file should be renamed to .viofosync.db.migrated"
+
+    # Sentinel data survived the copy.
+    db = Database(new_path)
+    with db.conn() as c:
+        row = c.execute(
+            "SELECT value FROM kv WHERE key = 'marker'"
+        ).fetchone()
+    assert row is not None
+    assert row["value"] == "legacy-data"
+
+
+def test_migrate_skips_when_new_path_already_exists(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """If a DB exists at the new path already, don't overwrite it and
+    don't rename the legacy file (the migration short-circuits at the
+    top)."""
+    rec = tmp_path / "rec"
+    cfg = tmp_path / "cfg"
+    rec.mkdir()
+    cfg.mkdir()
+    monkeypatch.setenv("RECORDINGS", str(rec))
+
+    legacy = rec / ".viofosync.db"
+    _seed_legacy_db(legacy)
+
+    new_path = cfg / "viofosync.db"
+    new_path.write_bytes(b"pre-existing content")
+
+    migrate_legacy_db_path(str(new_path))
+
+    assert new_path.read_bytes() == b"pre-existing content", \
+        "existing new-path file must not be overwritten"
+    assert legacy.exists(), \
+        "legacy file should remain untouched when migration short-circuits"
+
+
+def test_migrate_noop_when_legacy_missing(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """No legacy DB → helper returns without creating anything."""
+    rec = tmp_path / "rec"
+    cfg = tmp_path / "cfg"
+    rec.mkdir()
+    monkeypatch.setenv("RECORDINGS", str(rec))
+
+    new_path = cfg / "viofosync.db"
+    migrate_legacy_db_path(str(new_path))
+
+    assert not new_path.exists(), "no new DB should be created"
+    assert not (rec / ".viofosync.db.migrated").exists()
+
+
+def test_migrate_sidecar_copy_failure_is_non_fatal(
+    tmp_path: Path, monkeypatch, caplog,
+) -> None:
+    """Forcing a sidecar copy to fail must not abort the migration —
+    the main DB is still copied and the legacy file is still renamed."""
+    rec = tmp_path / "rec"
+    cfg = tmp_path / "cfg"
+    rec.mkdir()
+    monkeypatch.setenv("RECORDINGS", str(rec))
+
+    legacy = rec / ".viofosync.db"
+    _seed_legacy_db(legacy)
+    # Make the -wal path a directory so shutil.copy2 raises
+    # IsADirectoryError instead of copying a real WAL file.
+    (rec / ".viofosync.db-wal").mkdir()
+
+    new_path = cfg / "viofosync.db"
+    with caplog.at_level(logging.WARNING, logger="viofosync.db"):
+        migrate_legacy_db_path(str(new_path))
+
+    assert new_path.exists(), "main DB must still be copied"
+    assert (rec / ".viofosync.db.migrated").exists(), \
+        "legacy file must still be renamed"
+    assert any(
+        "could not copy" in lr.message for lr in caplog.records
+    ), "sidecar failure must be logged at WARNING"
+
+
+def test_default_db_path_uses_config_dir_env(monkeypatch) -> None:
+    """default_db_path resolves under CONFIG_DIR, with no leading dot."""
+    from web.db import default_db_path
+
+    monkeypatch.setenv("CONFIG_DIR", "/custom/cfg")
+    assert default_db_path() == "/custom/cfg/viofosync.db"
+
+
+def test_default_db_path_falls_back_to_default(monkeypatch) -> None:
+    """Without CONFIG_DIR set, default_db_path returns /config/viofosync.db."""
+    from web.db import default_db_path
+
+    monkeypatch.delenv("CONFIG_DIR", raising=False)
+    assert default_db_path() == "/config/viofosync.db"
+
+
+def test_database_init_does_not_migrate(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Database() must not trigger migration even when a legacy file
+    exists in RECORDINGS. This is the test-isolation guarantee that
+    lets the rest of the suite use `Database(tmp_path / "x.db")`
+    without risk of clobbering the host's real DB."""
+    rec = tmp_path / "rec"
+    rec.mkdir()
+    monkeypatch.setenv("RECORDINGS", str(rec))
+
+    legacy = rec / ".viofosync.db"
+    _seed_legacy_db(legacy)
+    legacy_bytes = legacy.read_bytes()
+
+    # Construct a fresh Database somewhere completely different. The
+    # legacy file must remain identical — no rename to .migrated, no
+    # truncation, no reads.
+    fresh = tmp_path / "fresh.db"
+    Database(str(fresh))
+
+    assert legacy.exists(), "legacy file must remain present"
+    assert legacy.read_bytes() == legacy_bytes, \
+        "legacy file contents must be untouched"
+    assert not (rec / ".viofosync.db.migrated").exists(), \
+        "legacy file must NOT have been renamed by Database()"

--- a/tests/test_lifespan_retention.py
+++ b/tests/test_lifespan_retention.py
@@ -1,0 +1,56 @@
+"""Integration tests for the lifespan-level retention scheduling."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+
+def test_lifespan_creates_background_retention_task(
+    tmp_config_dir: Path, tmp_recordings_dir: Path,
+) -> None:
+    """Startup must not block on the retention sweep — the sweep is
+    launched as a background asyncio task and the lifespan yields
+    immediately."""
+    from web import app as app_mod
+    from web import settings as settings_mod
+    settings_mod.reset_for_tests()
+    app = app_mod.create_app()
+
+    with TestClient(app):
+        assert hasattr(app.state, "retention_task"), (
+            "lifespan must set app.state.retention_task; without it the "
+            "startup retention sweep is still on the critical path"
+        )
+        assert isinstance(app.state.retention_task, asyncio.Task)
+
+
+def test_lifespan_shutdown_cancels_retention_task() -> None:
+    """The lifespan's `finally` block must explicitly cancel the
+    background retention task, so a container stop isn't blocked by
+    an in-flight sweep.
+
+    Behavioural assertions on this don't work: TestClient cancels
+    pending tasks during its own cleanup, so `task.cancelled()` ends
+    up True regardless of whether the lifespan called `.cancel()` on
+    `retention_task` or not. We inspect the lifespan source directly
+    to confirm the cancellation is wired up.
+    """
+    import inspect
+
+    from web import app as app_mod
+
+    src = inspect.getsource(app_mod.lifespan)
+    finally_idx = src.index("finally:")
+    finally_block = src[finally_idx:]
+
+    assert "retention_task" in finally_block, (
+        "lifespan's finally block must cancel app.state.retention_task; "
+        "otherwise a long-running sweep blocks container shutdown"
+    )
+    # Regression guard — the pre-existing initial_scan_task cancel must
+    # stay in place when we extend the loop.
+    assert "initial_scan_task" in finally_block, (
+        "initial_scan_task cancellation must remain in the finally block"
+    )

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -250,3 +250,75 @@ def test_sweep_disk_skips_ro_when_protected(env, monkeypatch) -> None:
             "SELECT basename FROM clip_index"
         ).fetchone()["basename"]
     assert remaining == "LOCK.MP4"
+
+
+def test_sweep_logs_examining_header_when_rows_exist(env, caplog) -> None:
+    """When there are eligible-by-time clips, sweep logs a single
+    'retention sweep: N clip(s) older than D days — examining' header
+    at INFO before starting deletions. Says 'examining' rather than
+    'deleting' because RO-protected rows are filtered inside the
+    loop, so N is the candidate count, not the eventual delete count."""
+    import logging
+    rec, db = env
+    now = 86400 * 365
+    _make_clip(rec, db, basename="A.MP4", ts=0)
+    _make_clip(rec, db, basename="B.MP4", ts=100)
+    _make_clip(rec, db, basename="C.MP4", ts=200)
+
+    with caplog.at_level(logging.INFO, logger="viofosync.retention"):
+        sweep(
+            db, str(rec), max_days=30, disk_pct=0,
+            protect_ro=False, _now=now,
+        )
+
+    headers = [
+        r.message for r in caplog.records
+        if "older than" in r.message and "examining" in r.message
+    ]
+    assert len(headers) == 1, f"expected one header log, got {headers}"
+    assert "3 clip(s) older than 30 days" in headers[0]
+
+
+def test_sweep_silent_when_no_eligible_clips(env, caplog) -> None:
+    """Steady-state: no eligible clips, no log noise."""
+    import logging
+    rec, db = env
+    now = 86400 * 365
+    _make_clip(rec, db, basename="NEW.MP4", ts=now - 3600)
+
+    with caplog.at_level(logging.INFO, logger="viofosync.retention"):
+        sweep(
+            db, str(rec), max_days=30, disk_pct=0,
+            protect_ro=False, _now=now,
+        )
+
+    assert caplog.records == [], \
+        f"sweep with no eligible clips must not log, got {[r.message for r in caplog.records]}"
+
+
+def test_sweep_logs_progress_every_10_deletions(env, caplog) -> None:
+    """A long time-phase sweep emits an INFO progress line at every
+    10th deletion, formatted with running count and MB freed."""
+    import logging
+    rec, db = env
+    now = 86400 * 365
+    # 25 eligible-by-time clips. Expect progress lines at the 10th
+    # and 20th deletions — two lines total.
+    for i in range(25):
+        _make_clip(rec, db, basename=f"OLD-{i:02d}.MP4", ts=i)
+
+    with caplog.at_level(logging.INFO, logger="viofosync.retention"):
+        sweep(
+            db, str(rec), max_days=30, disk_pct=0,
+            protect_ro=False, _now=now,
+        )
+
+    progress = [
+        r.message for r in caplog.records
+        if "/25 clip(s) deleted" in r.message
+    ]
+    assert len(progress) == 2, \
+        f"expected two progress lines, got {progress}"
+    assert progress[0].startswith("retention sweep: 10/25 clip(s) deleted")
+    assert progress[1].startswith("retention sweep: 20/25 clip(s) deleted")
+    assert "MB freed so far" in progress[0]

--- a/web/app.py
+++ b/web/app.py
@@ -30,6 +30,7 @@ from .routers import progress as progress_router
 from .routers import queue as queue_router
 from .routers import settings as settings_router
 from .routers import setup as setup_router
+from .services import retention as _ret_mod
 from .services import scanner
 from .services.exporter import (
     ExportWorker,
@@ -91,20 +92,6 @@ async def lifespan(app: FastAPI):
     if n_jobs:
         log.info("marked %d orphan export job(s) as failed", n_jobs)
 
-    # Retention sweep — sweep() emits its own INFO line when work
-    # was done, so we don't need to duplicate it here.
-    from .services import retention as _ret_mod
-    try:
-        await asyncio.to_thread(
-            _ret_mod.sweep,
-            app.state.db, s.recordings,
-            max_days=s.retention_max_days,
-            disk_pct=s.retention_disk_pct,
-            protect_ro=s.retention_protect_ro,
-        )
-    except Exception:  # pragma: no cover — non-fatal
-        log.exception("startup retention sweep failed")
-
     log.info(
         "viofosync web UI ready on http://%s:%d", s.host, s.port
     )
@@ -134,6 +121,20 @@ async def lifespan(app: FastAPI):
             log.warning("thumb sweep failed: %s", e)
 
     app.state.initial_scan_task = asyncio.create_task(_background_scan())
+
+    async def _background_retention() -> None:
+        try:
+            await asyncio.to_thread(
+                _ret_mod.sweep,
+                app.state.db, s.recordings,
+                max_days=s.retention_max_days,
+                disk_pct=s.retention_disk_pct,
+                protect_ro=s.retention_protect_ro,
+            )
+        except Exception:  # pragma: no cover — non-fatal
+            log.exception("startup retention sweep failed")
+
+    app.state.retention_task = asyncio.create_task(_background_retention())
 
     app.state.hub = Hub()
     app.state.geocode = GeocodeService(app.state.db, provider)
@@ -173,9 +174,10 @@ async def lifespan(app: FastAPI):
         yield
     finally:
         log.info("viofosync web UI shutting down")
-        task = getattr(app.state, "initial_scan_task", None)
-        if task is not None and not task.done():
-            task.cancel()
+        for attr in ("initial_scan_task", "retention_task"):
+            task = getattr(app.state, attr, None)
+            if task is not None and not task.done():
+                task.cancel()
         await app.state.sync_worker.stop()
         await app.state.export_worker.stop()
 

--- a/web/app.py
+++ b/web/app.py
@@ -22,7 +22,7 @@ from fastapi.staticfiles import StaticFiles
 
 from . import settings as settings_mod
 from .auth import Auth
-from .db import Database
+from .db import Database, default_db_path, migrate_legacy_db_path
 from .routers import archive as archive_router
 from .routers import auth as auth_router
 from .routers import exports as exports_router
@@ -75,9 +75,9 @@ async def lifespan(app: FastAPI):
 
     provider.subscribe(_on_settings_changed)
 
-    app.state.db = Database(
-        os.path.join(s.recordings, ".viofosync.db")
-    )
+    db_path = default_db_path()
+    migrate_legacy_db_path(db_path)
+    app.state.db = Database(db_path)
 
     # Reset any rows still marked downloading/running from the
     # previous process — those owners are gone, so the workers

--- a/web/db.py
+++ b/web/db.py
@@ -1,21 +1,95 @@
 """SQLite state store for the web UI.
 
-Lives at ``$RECORDINGS/.viofosync.db`` so it travels with the
-archive volume. WAL mode so readers don't block the SyncWorker
-writer.
+Lives at ``$CONFIG_DIR/viofosync.db`` (default
+``/config/viofosync.db``) so per-write syscalls hit a fast local
+volume rather than the NAS-backed recordings mount. On first boot
+under this code path a DB at the legacy
+``$RECORDINGS/.viofosync.db`` location is copied over and the
+legacy file is renamed to ``.viofosync.db.migrated`` so an
+operator has a fallback. See ``migrate_legacy_db_path`` for the
+one-shot migration helper; ``Database.__init__`` itself does not
+run migration so tests can construct ``Database(tmp_path)`` safely.
+
+WAL mode so readers don't block the SyncWorker writer.
 
 Schema is created on first boot and migrated idempotently via
-``CREATE TABLE IF NOT EXISTS``. There is no migration system
-yet — keep columns additive and nullable.
+``CREATE TABLE IF NOT EXISTS``. There is no schema migration
+system yet — keep columns additive and nullable.
 """
 
 from __future__ import annotations
 
+import logging
 import os
+import shutil
 import sqlite3
 import threading
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Iterator
+
+
+log = logging.getLogger("viofosync.db")
+
+
+def default_db_path() -> str:
+    """Return the production location of the state DB.
+
+    Lives under CONFIG_DIR (default /config) so per-write syscalls
+    hit a fast local volume rather than the NAS-backed recordings
+    mount. The leading dot is dropped from the filename — there is
+    no longer any reason to hide the DB on its own dedicated volume.
+    """
+    return str(
+        Path(os.environ.get("CONFIG_DIR", "/config")) / "viofosync.db"
+    )
+
+
+def migrate_legacy_db_path(new_path: str) -> None:
+    """Copy a legacy ${RECORDINGS}/.viofosync.db to ``new_path`` on
+    first boot. Idempotent: no-op when the new path already exists
+    or when the legacy path is missing.
+
+    Call exactly once at startup, before constructing ``Database``.
+    Not invoked from ``Database.__init__`` so test code constructing
+    ``Database(tmp_path)`` never reads the host's RECORDINGS env var.
+    """
+    if os.path.exists(new_path):
+        return
+    legacy_recordings = os.environ.get("RECORDINGS", "/recordings")
+    legacy_path = os.path.join(legacy_recordings, ".viofosync.db")
+    if not os.path.exists(legacy_path):
+        return
+
+    os.makedirs(os.path.dirname(new_path) or ".", exist_ok=True)
+    log.info("migrating state db: %s -> %s", legacy_path, new_path)
+
+    # Main file via temp suffix + os.replace so a crash mid-copy
+    # leaves no half-written file at the destination.
+    tmp = new_path + ".part"
+    shutil.copy2(legacy_path, tmp)
+    os.replace(tmp, new_path)
+
+    # Sidecars best-effort. SQLite reconstructs from the main file
+    # alone if these are missing or stale, so a failure here is not
+    # fatal — log and continue.
+    for suffix in ("-wal", "-shm"):
+        src = legacy_path + suffix
+        if not os.path.exists(src):
+            continue
+        try:
+            shutil.copy2(src, new_path + suffix)
+        except OSError as e:
+            # best-effort: SQLite reconstructs from the main file alone
+            log.warning("could not copy %s%s: %s", legacy_path, suffix, e)
+
+    # Rename the legacy file so we don't re-migrate next boot, and
+    # so the operator has a recoverable copy. Legacy -wal / -shm
+    # files are left in place — harmless.
+    try:
+        os.replace(legacy_path, legacy_path + ".migrated")
+    except OSError as e:  # pragma: no cover — non-fatal
+        log.warning("could not rename legacy db: %s", e)
 
 
 _SCHEMA = """

--- a/web/services/retention.py
+++ b/web/services/retention.py
@@ -118,6 +118,15 @@ def sweep(
                     (now - max_days * 86400,),
                 ).fetchall()
             ]
+        if rows:
+            # "examining" rather than "deleting": with protect_ro on,
+            # some rows here are RO-locked and will be skipped. The
+            # end-of-sweep summary reports the real deleted count.
+            log.info(
+                "retention sweep: %d clip(s) older than %d days "
+                "— examining",
+                len(rows), max_days,
+            )
         for row in rows:
             ok, reason = _eligible_by_time(
                 row, now=now, max_days=max_days, protect_ro=protect_ro,
@@ -130,6 +139,12 @@ def sweep(
             _delete_index_row(db, row["id"])
             deleted_time += 1
             _broadcast(sink, row["basename"], "time")
+            if deleted_time % 10 == 0:
+                log.info(
+                    "retention sweep: %d/%d clip(s) deleted "
+                    "(%.1f MB freed so far)",
+                    deleted_time, len(rows), bytes_freed / (1 << 20),
+                )
 
     # Phase 2: disk-pressure.
     deleted_disk = 0


### PR DESCRIPTION
### Fixed

- DB now lives in the `/config` volume rather than the recordings  
mount for better performance when the recordings are on  
slower storage.
- The startup retention sweep runs in the background rather than  
blocking the UI when there's a large delete backlog.

### Changed

- Retention sweep logs progress: a header when the time-phase has  
work, then a line every 10 deletions. Previously silent until the  
end-of-sweep summary.

### Migration

- An existing DB at `${RECORDINGS}/.viofosync.db` is copied to  
`${CONFIG_DIR}/viofosync.db` on first boot under v2.1. The legacy  
file is renamed to `.viofosync.db.migrated` on the recordings  
volume as a recoverable fallback.