### PR TITLE
Refresh stale source_dir on already-queued rows

### DIFF
--- a/tests/test_refresh_listing.py
+++ b/tests/test_refresh_listing.py
@@ -108,6 +108,43 @@ async def test_refresh_picks_up_clips_added_between_calls(
     ]
 
 
+async def test_refresh_updates_source_dir_when_clip_moves_to_ro(
+    db: Database,
+) -> None:
+    """If the user locks a clip mid-cycle the dashcam moves it
+    from /DCIM/Movie to /DCIM/Movie/RO. The next reconcile must
+    refresh source_dir on the existing row, otherwise the
+    download worker keeps hitting the stale path and 404s out
+    its retry budget."""
+    provider = MagicMock()
+    provider.get.return_value = _make_snap()
+    hub = Hub()
+    worker = SyncWorker(db, provider, hub)
+
+    with patch.object(worker, "_fetch_listing",
+                      return_value=[_Rec("A.MP4", filepath="/DCIM/Movie")]), \
+         patch.object(worker, "_present_filenames", return_value=[]):
+        await worker._refresh_listing_and_reconcile()
+
+    with db.conn() as c:
+        row = c.execute(
+            "SELECT source_dir FROM download_queue WHERE filename='A.MP4'"
+        ).fetchone()
+    assert row["source_dir"] == "/DCIM/Movie"
+
+    # User locks the clip; dashcam re-reports it under /RO.
+    with patch.object(worker, "_fetch_listing",
+                      return_value=[_Rec("A.MP4", filepath="/DCIM/Movie/RO")]), \
+         patch.object(worker, "_present_filenames", return_value=[]):
+        await worker._refresh_listing_and_reconcile()
+
+    with db.conn() as c:
+        row = c.execute(
+            "SELECT source_dir FROM download_queue WHERE filename='A.MP4'"
+        ).fetchone()
+    assert row["source_dir"] == "/DCIM/Movie/RO"
+
+
 async def test_refresh_filters_by_ro_only_when_setting_on(
     db: Database,
 ) -> None:

--- a/web/services/queue.py
+++ b/web/services/queue.py
@@ -66,11 +66,12 @@ def reconcile(
     added = 0
     marked_gone = 0
     marked_done = 0
+    refreshed_source_dir = 0
     with db.write() as c:
         existing = {
             row["filename"]: dict(row)
             for row in c.execute(
-                "SELECT filename, state FROM download_queue"
+                "SELECT filename, state, source_dir FROM download_queue"
             ).fetchall()
         }
 
@@ -115,6 +116,22 @@ def reconcile(
                 continue
 
             if filename in existing:
+                # Locking a clip on the dashcam moves it from
+                # /DCIM/Movie to /DCIM/Movie/RO. The fresh listing
+                # carries the new path; refresh the queue row so
+                # the worker doesn't keep retrying the stale URL.
+                fresh_source = getattr(rec, "filepath", "") or ""
+                if (
+                    fresh_source
+                    and existing[filename]["source_dir"] != fresh_source
+                    and existing[filename]["state"] in ("pending", "failed")
+                ):
+                    c.execute(
+                        "UPDATE download_queue SET source_dir=? "
+                        "WHERE filename=?",
+                        (fresh_source, filename),
+                    )
+                    refreshed_source_dir += 1
                 continue
 
             c.execute(
@@ -158,6 +175,7 @@ def reconcile(
         "added": added,
         "marked_gone": marked_gone,
         "marked_done": marked_done,
+        "refreshed_source_dir": refreshed_source_dir,
     }
 
 


### PR DESCRIPTION
## Summary

`reconcile()` in `web/services/queue.py` short-circuits on `if filename in existing: continue`, so an already-queued row's `source_dir` is never refreshed. When the user locks a clip on the dashcam between sync cycles the file moves from `/DCIM/Movie` to `/DCIM/Movie/RO`; the queue still points at the old path and the worker burns its full retry budget on HTTP 404 until the row is marked `failed` — and the clip never syncs.

The fix: when a fresh listing carries a different `filepath` for an already-queued filename, update `source_dir` — but only while the row is `pending` or `failed`. `done`/`downloading`/`gone` rows are left alone since their path is historical at that point. The reconcile summary dict gains a `refreshed_source_dir` count.

## When this triggers

Sync only runs while the dashcam is reachable over WiFi (typically parked at home in station mode), so the window is any active sync session:

1. Manual lock (rec button) while a sync session is running or between cycles
2. A parking-mode G-sensor event that locks a clip an earlier listing pass in the same session had already queued

Clips locked while driving are unaffected — by the next sync they're already under `/RO` and get queued with the correct path from the start.

## Test plan

- New regression test `test_refresh_updates_source_dir_when_clip_moves_to_ro` — fails on the unfixed reconcile, passes with the fix
- Full suite green
- Live-verified on a 3-camera A329: pressed the lock button mid-sync; the next reconcile picked up the path change for all three affected files (front/rear/telephoto) with `attempts=0` — no retry budget burned, downloads proceeded from the new `/RO` path