### PR TITLE
Complete 3-channel support: telephoto (T) and interior (I) cameras

### DIFF
--- a/tests/test_channel_of.py
+++ b/tests/test_channel_of.py
@@ -18,6 +18,14 @@ def test_channel_of_rear_variants():
 
 def test_channel_of_interior():
     assert naming.channel_of("I") == "interior"
+    assert naming.channel_of("PI") == "interior"  # parking interior
+
+
+def test_channel_of_tele():
+    assert naming.channel_of("T") == "tele"
+    assert naming.channel_of("PT") == "tele"    # parking tele
+    assert naming.channel_of("ET") == "tele"    # event tele
+    assert naming.channel_of("t") == "tele"     # case-insensitive
 
 
 def test_channel_of_unknown_and_empty():
@@ -27,8 +35,11 @@ def test_channel_of_unknown_and_empty():
 
 
 def test_channel_order_and_labels():
-    assert naming.CHANNEL_ORDER == ["front", "rear", "interior", "other"]
+    assert naming.CHANNEL_ORDER == [
+        "front", "rear", "tele", "interior", "other",
+    ]
     assert naming.CHANNEL_LABELS["front"] == "Front"
     assert naming.CHANNEL_LABELS["rear"] == "Rear"
+    assert naming.CHANNEL_LABELS["tele"] == "Tele"
     assert naming.CHANNEL_LABELS["interior"] == "Interior"
     assert naming.CHANNEL_LABELS["other"] == "Other"

--- a/tests/test_export_types.py
+++ b/tests/test_export_types.py
@@ -1,0 +1,57 @@
+"""Validation gates for the third-camera export job types.
+
+Two layers must both accept a type before a job can run: the
+route's pydantic pattern (web/routers/exports.py) and the
+worker's enqueue() allowlist (web/services/exporter.py). A type
+listed in one but not the other 422s or errors at runtime — pin
+them together.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from web.db import Database
+from web.routers.exports import CreateExport, Segment
+from web.services.exporter import ExportWorker
+
+NEW_TYPES = ("join_tele", "join_interior", "pip_tele", "pip_interior")
+OLD_TYPES = ("join_front", "join_rear", "pip", "pip_rear")
+
+
+def test_route_model_accepts_all_types():
+    for t in OLD_TYPES + NEW_TYPES + ("timeline",):
+        assert CreateExport(type=t).type == t
+
+
+def test_route_model_rejects_unknown_type():
+    with pytest.raises(ValidationError):
+        CreateExport(type="join_bogus")
+
+
+def test_segment_accepts_tele_and_interior_channels():
+    for ch in ("front", "rear", "tele", "interior", "other"):
+        seg = Segment(channel=ch, start_ts=0.0, end_ts=1.0)
+        assert seg.channel == ch
+    with pytest.raises(ValidationError):
+        Segment(channel="bogus", start_ts=0.0, end_ts=1.0)
+
+
+def test_enqueue_allowlist_accepts_new_types(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(
+        "web.services.exporter.ffmpeg_available", lambda: True,
+    )
+    db = Database(str(tmp_path / "test.db"))
+    worker = ExportWorker(
+        db=db, provider=MagicMock(), broadcast=MagicMock(),
+    )
+    for t in OLD_TYPES + NEW_TYPES:
+        job_id = worker.enqueue(t, [1, 2])
+        assert isinstance(job_id, int)
+    with pytest.raises(ValueError):
+        worker.enqueue("join_bogus", [1])

--- a/tests/test_exporter_pair_clips.py
+++ b/tests/test_exporter_pair_clips.py
@@ -1,0 +1,82 @@
+"""Tests for ExportWorker._pair_clips slot dispatch.
+
+The pairer groups same-capture clips by (timestamp, event_type)
+and assigns each clip a slot from its trailing camera letter:
+F → front, T → tele, I → interior, everything else → rear.
+``required`` names the slots a group must have to count — PiP
+front+rear needs both classic slots; pip_tele / pip_interior
+need front plus the third camera.
+"""
+from __future__ import annotations
+
+from web.services.exporter import ExportWorker
+
+
+def _clip(camera: str, ts: int = 1000, event: str = "normal") -> dict:
+    return {
+        "camera": camera,
+        "timestamp": ts,
+        "event_type": event,
+        "path": f"/x/{ts}_{camera}.MP4",
+    }
+
+
+def test_front_rear_pairing_unchanged():
+    pairs = ExportWorker._pair_clips(
+        [_clip("F"), _clip("R")],
+    )
+    assert len(pairs) == 1
+    (_, p), = pairs
+    assert p["front"]["camera"] == "F"
+    assert p["rear"]["camera"] == "R"
+
+
+def test_triplet_keeps_all_three_slots():
+    pairs = ExportWorker._pair_clips(
+        [_clip("F"), _clip("R"), _clip("T")],
+    )
+    (_, p), = pairs
+    assert set(p) == {"front", "rear", "tele"}
+
+
+def test_front_tele_pair_for_pip_tele():
+    # A front+tele selection has no rear — the default
+    # front+rear requirement drops it, the pip_tele one keeps it.
+    clips = [_clip("F"), _clip("T")]
+    assert ExportWorker._pair_clips(clips) == []
+    pairs = ExportWorker._pair_clips(
+        clips, required=("front", "tele"),
+    )
+    assert len(pairs) == 1
+
+
+def test_front_interior_pair_for_pip_interior():
+    clips = [_clip("F"), _clip("I")]
+    pairs = ExportWorker._pair_clips(
+        clips, required=("front", "interior"),
+    )
+    assert len(pairs) == 1
+    (_, p), = pairs
+    assert p["interior"]["camera"] == "I"
+
+
+def test_tele_only_never_pairs():
+    assert ExportWorker._pair_clips(
+        [_clip("T")], required=("front", "tele"),
+    ) == []
+
+
+def test_parking_prefixes_assign_correct_slots():
+    pairs = ExportWorker._pair_clips(
+        [_clip("PF", event="parking"), _clip("PT", event="parking")],
+        required=("front", "tele"),
+    )
+    (_, p), = pairs
+    assert p["front"]["camera"] == "PF"
+    assert p["tele"]["camera"] == "PT"
+
+
+def test_rear_tele_without_front_never_pairs():
+    assert ExportWorker._pair_clips(
+        [_clip("R"), _clip("T")], required=("front", "tele"),
+    ) == []

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -13,6 +13,12 @@ def test_classify_event_type():
     assert importer.classify_event_type("F", "DCIM/Movie/RO/X.MP4") == "ro"
     # RO wins even for a parking-named clip living under /RO/.
     assert importer.classify_event_type("PF", "Movie/RO/X.MP4") == "ro"
+    # Third cameras: telephoto (T) and interior (I) classify the
+    # same way as front/rear.
+    assert importer.classify_event_type("T", "DCIM/Movie/X.MP4") == "normal"
+    assert importer.classify_event_type("PT", "DCIM/Parking/X.MP4") == "parking"
+    assert importer.classify_event_type("I", "DCIM/Movie/X.MP4") == "normal"
+    assert importer.classify_event_type("PI", "Movie/RO/X.MP4") == "ro"
 
 
 def test_scan_source_recurses_and_sorts_newest_first(tmp_path: Path):
@@ -20,22 +26,26 @@ def test_scan_source_recurses_and_sorts_newest_first(tmp_path: Path):
     root = tmp_path / "card"
     (root / "DCIM" / "Movie").mkdir(parents=True)
     (root / "DCIM" / "Movie" / "RO").mkdir()
-    # Recognised: one older normal front, one newer locked front.
+    # Recognised: one older normal front, one newer locked front,
+    # and a telephoto clip from a 3-camera model.
     (root / "DCIM" / "Movie" / "2026_0101_080000_0001F.MP4").write_bytes(b"a" * 10)
     (root / "DCIM" / "Movie" / "RO" / "2026_0102_090000_0002F.MP4").write_bytes(b"b" * 20)
+    (root / "DCIM" / "Movie" / "2026_0101_081000_0003T.MP4").write_bytes(b"t" * 7)
     # Junk: ignored + reported.
     (root / "DCIM" / "Movie" / "notes.txt").write_text("hi")
     # Matches the filename regex but has an impossible date -> bad_timestamp.
     (root / "DCIM" / "Movie" / "2026_1399_250000_0009F.MP4").write_bytes(b"c" * 5)
 
     manifest = importer.scan_source(str(root))
-    assert manifest.total_bytes == 30
+    assert manifest.total_bytes == 37
     assert [it.basename for it in manifest.items] == [
         "2026_0102_090000_0002F.MP4",   # newest first
+        "2026_0101_081000_0003T.MP4",
         "2026_0101_080000_0001F.MP4",
     ]
     assert manifest.items[0].event_type == "ro"
-    assert manifest.items[1].event_type == "normal"
+    assert manifest.items[1].event_type == "normal"   # the T clip
+    assert manifest.items[2].event_type == "normal"
     skipped = {s["name"]: s["reason"] for s in manifest.skipped}
     assert skipped["notes.txt"] == "not_recognised"
     assert skipped["2026_1399_250000_0009F.MP4"] == "bad_timestamp"

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -54,7 +54,10 @@ def test_input_order_does_not_matter() -> None:
 
 def test_each_label_passes_through() -> None:
     clips = [_clip(_ts(2024, 3, 15, 14, 30))]
-    for label in ("front", "rear", "pip-front", "pip-rear"):
+    for label in (
+        "front", "rear", "tele", "interior",
+        "pip-front", "pip-rear", "pip-tele", "pip-interior",
+    ):
         assert build_basename(clips, label).endswith(f"_{label}_1clip")
 
 
@@ -74,6 +77,18 @@ def test_export_download_name_maps_type_and_adds_ext() -> None:
     )
     assert export_download_name("pip_rear", clips, 7) == (
         "2024-03-15_1430-1502_pip-rear_2clips.mp4"
+    )
+    assert export_download_name("join_tele", clips, 7) == (
+        "2024-03-15_1430-1502_tele_2clips.mp4"
+    )
+    assert export_download_name("join_interior", clips, 7) == (
+        "2024-03-15_1430-1502_interior_2clips.mp4"
+    )
+    assert export_download_name("pip_tele", clips, 7) == (
+        "2024-03-15_1430-1502_pip-tele_2clips.mp4"
+    )
+    assert export_download_name("pip_interior", clips, 7) == (
+        "2024-03-15_1430-1502_pip-interior_2clips.mp4"
     )
 
 

--- a/tests/test_pip_filter.py
+++ b/tests/test_pip_filter.py
@@ -72,3 +72,21 @@ def test_front_main_is_the_default() -> None:
     assert _pip_filter_complex("top_right") == (
         _pip_filter_complex("top_right", main="front")
     )
+
+
+# Tele-main / interior-main: the partner clip is ffmpeg input 1
+# (the input swap happens in _pip's argv construction, not here),
+# so any non-front ``main`` yields the same graph as rear-main —
+# partner fullscreen, front (input 0) scaled to the inset.
+
+
+def test_tele_main_matches_rear_main_graph() -> None:
+    assert _pip_filter_complex("top_right", main="tele") == (
+        _pip_filter_complex("top_right", main="rear")
+    )
+
+
+def test_interior_main_matches_rear_main_graph() -> None:
+    assert _pip_filter_complex("bottom_left", main="interior") == (
+        _pip_filter_complex("bottom_left", main="rear")
+    )

--- a/tests/test_queue_filename_parsing.py
+++ b/tests/test_queue_filename_parsing.py
@@ -1,0 +1,50 @@
+"""Tests for the queue's filename → camera / event-type parsers.
+
+Viofo filenames end ``…NNNNN[PE]?[FRTI].MP4`` — the trailing
+letter is the camera (F=front, R=rear, T=telephoto, I=interior)
+and the optional P/E prefix encodes parking/event clips.
+3-channel models pair F+R with either T or I.
+"""
+from __future__ import annotations
+
+from web.services.queue import (
+    _camera_from_filename,
+    _event_from_filename,
+)
+
+
+def test_camera_front_rear():
+    assert _camera_from_filename("2026_0513_172152_000120F.MP4") == "F"
+    assert _camera_from_filename("2026_0513_172152_000121R.MP4") == "R"
+    assert _camera_from_filename("2026_0513_172152_000122PF.MP4") == "F"
+    assert _camera_from_filename("2026_0513_172152_000123ER.MP4") == "R"
+
+
+def test_camera_tele():
+    assert _camera_from_filename("2026_0513_172152_000124T.MP4") == "T"
+    assert _camera_from_filename("2026_0513_172152_000125PT.MP4") == "T"
+    assert _camera_from_filename("2026_0513_172152_000126ET.MP4") == "T"
+
+
+def test_camera_interior():
+    assert _camera_from_filename("2026_0109_143514_000487I.MP4") == "I"
+    assert _camera_from_filename("2026_0109_145126_000520PI.MP4") == "I"
+    assert _camera_from_filename("2026_0109_145126_000521EI.MP4") == "I"
+
+
+def test_camera_case_insensitive():
+    assert _camera_from_filename("2026_0513_172152_000124t.mp4") == "T"
+
+
+def test_camera_unknown_letter_rejected():
+    assert _camera_from_filename("2026_0513_172152_000124X.MP4") is None
+    assert _camera_from_filename("notes.txt") is None
+
+
+def test_event_type_for_third_cameras():
+    assert _event_from_filename("2026_0513_172152_000124T.MP4") == "normal"
+    assert _event_from_filename("2026_0513_172152_000125PT.MP4") == "parking"
+    assert _event_from_filename("2026_0513_172152_000126ET.MP4") == "event"
+    assert _event_from_filename("2026_0109_143514_000487I.MP4") == "normal"
+    assert _event_from_filename("2026_0109_145126_000520PI.MP4") == "parking"
+    assert _event_from_filename("2026_0109_145126_000521EI.MP4") == "event"

--- a/tests/test_timeline_endpoint.py
+++ b/tests/test_timeline_endpoint.py
@@ -93,8 +93,10 @@ def test_timeline_day_mode_channels_clips_bounds(logged_in_client):
 
 
 def test_timeline_third_camera_channels(logged_in_client):
-    """A 3-camera day (here telephoto) exposes a third channel,
-    ordered after rear. Interior would slot in the same way."""
+    """Tele and interior clips each get their own channel, in
+    CHANNEL_ORDER after rear. A real device has only one of the
+    two, but the endpoint must order any mix it finds — e.g. an
+    archive that spans both a telephoto and an interior setup."""
     app = logged_in_client.app
     _insert_clip(app, 1, 1_717_312_440, "F", 60.0)
     _insert_clip(app, 2, 1_717_312_440, "R", 60.0)

--- a/tests/test_timeline_endpoint.py
+++ b/tests/test_timeline_endpoint.py
@@ -92,6 +92,31 @@ def test_timeline_day_mode_channels_clips_bounds(logged_in_client):
     assert body["gps"] is None
 
 
+def test_timeline_third_camera_channels(logged_in_client):
+    """A 3-camera day (here telephoto) exposes a third channel,
+    ordered after rear. Interior would slot in the same way."""
+    app = logged_in_client.app
+    _insert_clip(app, 1, 1_717_312_440, "F", 60.0)
+    _insert_clip(app, 2, 1_717_312_440, "R", 60.0)
+    _insert_clip(app, 3, 1_717_312_440, "T", 60.0)
+    _insert_clip(app, 4, 1_717_312_440, "I", 60.0)
+
+    r = logged_in_client.get("/api/archive/timeline?date=2026-06-02")
+    assert r.status_code == 200
+    body = r.json()
+    assert [ch["key"] for ch in body["channels"]] == [
+        "front", "rear", "tele", "interior",
+    ]
+    labels = {ch["key"]: ch["label"] for ch in body["channels"]}
+    assert labels["tele"] == "Tele"
+    assert labels["interior"] == "Interior"
+    by_channel = {}
+    for c in body["clips"]:
+        by_channel.setdefault(c["channel"], []).append(c)
+    assert len(by_channel["tele"]) == 1
+    assert len(by_channel["interior"]) == 1
+
+
 def test_timeline_journey_mode_windows_clips(logged_in_client, monkeypatch):
     app = logged_in_client.app
     _insert_clip(app, 1, 1_717_312_440, "F", 60.0)

--- a/viofosync_lib/_archive.py
+++ b/viofosync_lib/_archive.py
@@ -30,11 +30,13 @@ group_name_globs = {
     "yearly": "[0-9][0-9][0-9][0-9]",
 }
 
-# Downloaded recording filename glob pattern.
+# Downloaded recording filename glob pattern. The trailing
+# letter is the camera: F=front, R=rear, T=telephoto,
+# I=interior.
 downloaded_filename_glob = (
     "[0-9][0-9][0-9][0-9]_[0-9][0-9][0-9][0-9]"
     "_[0-9][0-9][0-9][0-9][0-9][0-9]"
-    "_*[FR].MP4"
+    "_*[FRTI].MP4"
 )
 
 # Downloaded recording filename regular expression.

--- a/web/routers/archive.py
+++ b/web/routers/archive.py
@@ -197,13 +197,19 @@ def get_day(
                 pass
         return True
 
-    # Pair front+rear by (timestamp, event_type). Viofo's F and R
-    # from one capture share a timestamp but get consecutive
-    # sequence numbers, so keying on sequence wouldn't pair them.
+    # Group cameras by (timestamp, event_type). Viofo clips from
+    # one capture share a timestamp but get consecutive sequence
+    # numbers, so keying on sequence wouldn't pair them.
     # event_type keeps parking (PF/PR) separate from normal (F/R).
     # Slot is picked from the last letter so PF/EF still = front.
+    # 3-channel models add either T (telephoto) or I (interior)
+    # alongside F+R.
     pairs: dict[tuple[int, str], dict] = defaultdict(
-        lambda: {"front": None, "rear": None, "sequence": None}
+        lambda: {
+            "front": None, "rear": None,
+            "tele": None, "interior": None,
+            "sequence": None,
+        }
     )
     for r in rows:
         if not _in_range(r["timestamp"]):
@@ -211,10 +217,12 @@ def get_day(
         cam = (r["camera"] or "").upper()
         kind = r["event_type"] or "normal"
         key = (r["timestamp"], kind)
-        slot = "front" if cam.endswith("F") else "rear"
+        slot = {"F": "front", "T": "tele", "I": "interior"}.get(
+            cam[-1:], "rear"
+        )
         pairs[key][slot] = dict(r)
         # Prefer the front sequence number for the pair; fall
-        # back to the rear's if there's no front clip.
+        # back to any other camera's if there's no front clip.
         if slot == "front" or pairs[key]["sequence"] is None:
             pairs[key]["sequence"] = r["sequence"]
 
@@ -228,6 +236,8 @@ def get_day(
             "iso": _dt.datetime.fromtimestamp(ts).isoformat(),
             "front": pair["front"],
             "rear": pair["rear"],
+            "tele": pair["tele"],
+            "interior": pair["interior"],
         })
 
     return {"date": date, "clips": clips}

--- a/web/routers/exports.py
+++ b/web/routers/exports.py
@@ -55,14 +55,17 @@ def _resolve_default_encoder(app_state) -> str:
 
 
 class Segment(BaseModel):
-    channel: str = Field(pattern="^(front|rear|interior|other)$")
+    channel: str = Field(pattern="^(front|rear|tele|interior|other)$")
     start_ts: float
     end_ts: float
 
 
 class CreateExport(BaseModel):
     type: str = Field(
-        pattern="^(join_front|join_rear|pip|pip_rear|timeline)$"
+        pattern=(
+            "^(join_front|join_rear|join_tele|join_interior"
+            "|pip|pip_rear|pip_tele|pip_interior|timeline)$"
+        )
     )
     clip_ids: List[int] = []
     segments: list[Segment] | None = None

--- a/web/services/exporter.py
+++ b/web/services/exporter.py
@@ -391,19 +391,21 @@ def _pip_filter_complex(
 ) -> str:
     """Build the -filter_complex argument for the PiP overlay.
 
-    ffmpeg input 0 is the front clip, input 1 is the rear clip.
-    ``main`` chooses which is the fullscreen base layer; the other
-    is scaled to 1/4 size and overlaid. ``main="front"`` (default)
-    reproduces the original front-fullscreen behaviour. Unknown
-    ``position`` values fall back to ``top_right`` so a typo
-    doesn't break ffmpeg invocation entirely.
+    ffmpeg input 0 is the front clip, input 1 is the partner clip
+    (rear, tele or interior). ``main`` chooses which is the
+    fullscreen base layer; the other is scaled to 1/4 size and
+    overlaid. ``main="front"`` (default) reproduces the original
+    front-fullscreen behaviour; any other value (rear / tele /
+    interior) makes the partner fullscreen with the front inset.
+    Unknown ``position`` values fall back to ``top_right`` so a
+    typo doesn't break ffmpeg invocation entirely.
     """
     coords = _PIP_OVERLAY_COORDS.get(
         position, _PIP_OVERLAY_COORDS["top_right"],
     )
-    # Only "front" / "rear" are ever passed (derived from the job
-    # type); anything else falls through to rear-main rather than
-    # erroring, matching the lenient position handling above.
+    # ``main`` is derived from the job type (front / rear / tele /
+    # interior); anything that isn't "front" means partner-main,
+    # matching the lenient position handling above.
     base, inset = ("0", "1") if main == "front" else ("1", "0")
     if encoder == "qsv":
         # GPU composition: scale_qsv shrinks the inset, overlay_qsv composes
@@ -617,7 +619,10 @@ class ExportWorker:
     ) -> int:
         if not ffmpeg_available():
             raise RuntimeError("ffmpeg not installed on this host")
-        if job_type not in ("join_front", "join_rear", "pip", "pip_rear"):
+        if job_type not in (
+            "join_front", "join_rear", "join_tele", "join_interior",
+            "pip", "pip_rear", "pip_tele", "pip_interior",
+        ):
             raise ValueError(f"unknown job type: {job_type}")
         if not clip_ids:
             raise ValueError("no clips selected")
@@ -888,8 +893,14 @@ class ExportWorker:
 
         clips = self._fetch_clips(clip_ids)
 
-        if job["type"] in ("join_front", "join_rear"):
-            wanted = "F" if job["type"] == "join_front" else "R"
+        join_wanted = {
+            "join_front": "F",
+            "join_rear": "R",
+            "join_tele": "T",
+            "join_interior": "I",
+        }
+        if job["type"] in join_wanted:
+            wanted = join_wanted[job["type"]]
             # ``camera`` may be ``F``, ``R``, ``PF``, ``PR``, etc.
             # The last letter identifies the lens.
             selected = [
@@ -903,38 +914,57 @@ class ExportWorker:
                 )
                 return
             await self._concat(job["id"], selected, out)
-        else:  # pip / pip_rear
-            pairs = self._pair_clips(clips)
+        else:  # pip / pip_rear / pip_tele / pip_interior
+            # The PiP partner is the non-front camera; ``main``
+            # chooses which side is fullscreen. Front is always
+            # ffmpeg input 0 (it carries the mic audio).
+            partner = {
+                "pip_tele": "tele",
+                "pip_interior": "interior",
+            }.get(job["type"], "rear")
+            pairs = self._pair_clips(
+                clips, required=("front", partner),
+            )
             if not pairs:
                 self._finish(
                     job["id"], False,
-                    "no front+rear pairs in selection", None,
+                    f"no front+{partner} pairs in selection", None,
                 )
                 return
-            main = "rear" if job["type"] == "pip_rear" else "front"
+            main = {
+                "pip_rear": "rear",
+                "pip_tele": "tele",
+                "pip_interior": "interior",
+            }.get(job["type"], "front")
             await self._pip(
                 job["id"], pairs, out, encoder,
-                snap.pip_position, main=main,
+                snap.pip_position, main=main, partner=partner,
             )
 
     # ---- ffmpeg invocations ----
 
     @staticmethod
-    def _pair_clips(clips: List[dict]):
-        # Viofo gives F and R from the same capture identical
-        # timestamps but consecutive sequences, so key on
-        # (timestamp, event_type) and pick the slot from the
-        # trailing letter of ``camera`` (handles PF/PR too).
+    def _pair_clips(
+        clips: List[dict],
+        required: tuple = ("front", "rear"),
+    ):
+        # Viofo gives same-capture clips identical timestamps but
+        # consecutive sequences, so key on (timestamp, event_type)
+        # and pick the slot from the trailing letter of ``camera``
+        # (handles PF/PR/PT/PI too). ``required`` names the slots
+        # a group must have to count as a complete pair.
         pairs: dict[tuple[int, str], dict] = {}
         for c in clips:
             cam = (c["camera"] or "").upper()
             kind = c.get("event_type") or "normal"
             key = (c["timestamp"], kind)
-            slot = "front" if cam.endswith("F") else "rear"
+            slot = {"F": "front", "T": "tele", "I": "interior"}.get(
+                cam[-1:], "rear"
+            )
             pairs.setdefault(key, {})[slot] = c
         return [
             p for p in sorted(pairs.items())
-            if "front" in p[1] and "rear" in p[1]
+            if all(s in p[1] for s in required)
         ]
 
     async def _concat(
@@ -986,8 +1016,14 @@ class ExportWorker:
         encoder: str = "software",
         position: str = "top_right",
         main: str = "front",
+        partner: str = "rear",
     ) -> None:
         """One ffmpeg per pair into a temp dir, then concat.
+
+        ``partner`` names the non-front slot in each pair (rear,
+        tele or interior). Front is always ffmpeg input 0 — it
+        carries the mic audio, and ``-c:a copy`` with no explicit
+        ``-map`` makes ffmpeg's default stream selection pick it.
 
         Broadcasts segment-level progress so the UI shows
         something meaningful even though each segment is a
@@ -1000,9 +1036,9 @@ class ExportWorker:
             for i, (_, p) in enumerate(pairs):
                 # Probe this segment's duration so the inner
                 # pump() can emit fine-grained progress instead
-                # of sitting silent for minutes. Front and rear of a
-                # Viofo pair share a duration, so the front clip is a
-                # fine reference even for rear-main (pip_rear).
+                # of sitting silent for minutes. All cameras of a
+                # Viofo capture share a duration, so the front clip
+                # is a fine reference even for partner-main jobs.
                 seg_dur = await self._probe_total(
                     [p["front"]]
                 )
@@ -1026,7 +1062,7 @@ class ExportWorker:
                         *_hw_decode_args(encoder),
                         "-i", p["front"]["path"],
                         *_hw_decode_args(encoder),
-                        "-i", p["rear"]["path"],
+                        "-i", p[partner]["path"],
                         # _with_upload appends hwupload for VAAPI only; for QSV
                         # the filter already yields GPU surfaces, so it's a no-op.
                         "-filter_complex",

--- a/web/services/naming.py
+++ b/web/services/naming.py
@@ -24,8 +24,12 @@ from typing import List
 LABEL_FOR_TYPE = {
     "join_front": "front",
     "join_rear": "rear",
-    "pip": "pip-front",       # front-main PiP
-    "pip_rear": "pip-rear",   # rear-main PiP
+    "join_tele": "tele",
+    "join_interior": "interior",
+    "pip": "pip-front",               # front-main PiP
+    "pip_rear": "pip-rear",           # rear-main PiP
+    "pip_tele": "pip-tele",           # tele-main + front inset
+    "pip_interior": "pip-interior",   # interior-main + front inset
 }
 
 
@@ -91,16 +95,23 @@ def export_download_name(
 # --- Timeline camera channels -------------------------------------------
 
 # The lens is the trailing letter of a clip's ``camera`` code:
-# F / PF (parking) / EF (event) -> front; R / PR -> rear; a future
-# interior lens is I. Anything else falls back to "other" so an
+# F / PF (parking) / EF (event) -> front; R / PR -> rear;
+# T -> telephoto; I -> interior. 3-channel models pair F+R with
+# either T or I. Anything else falls back to "other" so an
 # unexpected code still gets its own track rather than vanishing.
-_CHANNEL_FOR_LETTER = {"F": "front", "R": "rear", "I": "interior"}
+_CHANNEL_FOR_LETTER = {
+    "F": "front",
+    "R": "rear",
+    "T": "tele",
+    "I": "interior",
+}
 
 # Stable display order for channel tracks, and human labels.
-CHANNEL_ORDER = ["front", "rear", "interior", "other"]
+CHANNEL_ORDER = ["front", "rear", "tele", "interior", "other"]
 CHANNEL_LABELS = {
     "front": "Front",
     "rear": "Rear",
+    "tele": "Tele",
     "interior": "Interior",
     "other": "Other",
 }

--- a/web/services/queue.py
+++ b/web/services/queue.py
@@ -164,10 +164,12 @@ def reconcile(
 def _camera_from_filename(filename: str) -> Optional[str]:
     # Handles both ``…_0001F.MP4`` and ``…_0001PF.MP4`` /
     # ``…_0001EF.MP4`` — the optional prefix letter encodes the
-    # event type (P=parking, E=event).
+    # event type (P=parking, E=event). The camera letter is
+    # F=front, R=rear, T=telephoto, I=interior — 3-channel
+    # models pair F+R with either T or I.
     import re as _re
     m = _re.match(
-        r"^\d{4}_\d{4}_\d{6}_\d+[PE]?([FR])\.MP4$",
+        r"^\d{4}_\d{4}_\d{6}_\d+[PE]?([FRTI])\.MP4$",
         filename,
         _re.IGNORECASE,
     )
@@ -177,7 +179,7 @@ def _camera_from_filename(filename: str) -> Optional[str]:
 def _event_from_filename(filename: str) -> Optional[str]:
     import re as _re
     m = _re.match(
-        r"^\d{4}_\d{4}_\d{6}_\d+([PE])?[FR]\.MP4$",
+        r"^\d{4}_\d{4}_\d{6}_\d+([PE])?[FRTI]\.MP4$",
         filename,
         _re.IGNORECASE,
     )
@@ -190,7 +192,7 @@ def _event_from_filename(filename: str) -> Optional[str]:
 # SQL expressions for deriving camera / event type straight
 # from the filename. Used for filtering so we don't depend on
 # historical rows having ``camera`` / ``event_type`` populated.
-# Filenames end in ``…NNNNN[PE]?[FR].MP4`` — the camera letter
+# Filenames end in ``…NNNNN[PE]?[FRTI].MP4`` — the camera letter
 # is the character immediately before ``.MP4``, and the byte
 # before that is either a digit (normal) or P/E.
 _CAM_SQL = "upper(substr(filename, -5, 1))"

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1109,8 +1109,9 @@ function updateArchiveActions() {
   document.getElementById("export-pip-front").disabled = !hasPair;
   document.getElementById("export-pip-rear").disabled = !hasPair;
   // Third-camera (tele / interior) actions: the whole button group
-  // stays hidden unless that camera appears in the day's data, so
-  // 2-camera setups see the original action bar unchanged.
+  // stays hidden until the selection contains a clip from that
+  // camera, so 2-camera setups see the original action bar
+  // unchanged.
   const camGroup = (cam, present, dl, join, pip, pipOk) => {
     const group = document.getElementById(`actions-${cam}`);
     if (!group) return;

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -19,7 +19,7 @@ const state = {
   queueSelected: new Set(),// filenames ticked
   filters: { driving: true, parking: true, ro: true },
   showMaps: localStorage.getItem("vfs.showMaps") !== "0",
-  archiveSelected: new Map(),  // pair_id → { ts, front, rear }
+  archiveSelected: new Map(),  // pair_id → { ts, front, rear, tele, interior }
   archiveExpanded: new Set(),  // open archive day keys ("YYYY-MM-DD"); persists
                                // open days across in-app navigation (re-render)
   map: null,
@@ -983,7 +983,11 @@ function renderClipPair(pair) {
       <label><input type="checkbox" data-pair="${pair.timestamp}_${pair.sequence}" /> ${time}</label>
       ${kindBadge}
     </div>
-    <div class="thumbs">${thumb(pair.front, "F")}${thumb(pair.rear, "R")}</div>
+    <div class="thumbs">${thumb(pair.front, "F")}${thumb(pair.rear, "R")}${
+      // Third camera (telephoto or interior) renders only when
+      // present so 2-camera days keep their familiar two columns.
+      pair.tele ? thumb(pair.tele, "T") : ""
+    }${pair.interior ? thumb(pair.interior, "I") : ""}</div>
   `;
   el.querySelectorAll(".thumb img").forEach((img) => {
     img.addEventListener("click", (e) => {
@@ -1000,14 +1004,16 @@ function renderClipPair(pair) {
   if (state.archiveSelected.has(pairId)) cb.checked = true;
   cb.addEventListener("change", () => {
     if (cb.checked) {
-      const front = el.querySelector('.thumb[data-camera="F"]');
-      const rear = el.querySelector('.thumb[data-camera="R"]');
+      const clipId = (cam) => {
+        const t = el.querySelector(`.thumb[data-camera="${cam}"]`);
+        return t && t.dataset.clipId ? Number(t.dataset.clipId) : null;
+      };
       state.archiveSelected.set(pairId, {
         ts: Number(el.dataset.ts),
-        front: front && front.dataset.clipId
-          ? Number(front.dataset.clipId) : null,
-        rear: rear && rear.dataset.clipId
-          ? Number(rear.dataset.clipId) : null,
+        front: clipId("F"),
+        rear: clipId("R"),
+        tele: clipId("T"),
+        interior: clipId("I"),
       });
     } else {
       state.archiveSelected.delete(pairId);
@@ -1085,10 +1091,15 @@ function updateArchiveActions() {
     bar.classList.add("has-selection");
   }
   let fronts = 0, rears = 0, both = 0;
+  let teles = 0, interiors = 0, frontTele = 0, frontInterior = 0;
   for (const v of state.archiveSelected.values()) {
     if (v.front) fronts++;
     if (v.rear) rears++;
     if (v.front && v.rear) both++;
+    if (v.tele) teles++;
+    if (v.interior) interiors++;
+    if (v.front && v.tele) frontTele++;
+    if (v.front && v.interior) frontInterior++;
   }
   const hasFront = fronts > 0, hasRear = rears > 0, hasPair = both > 0;
   document.getElementById("dl-orig-front").disabled = !hasFront;
@@ -1097,6 +1108,28 @@ function updateArchiveActions() {
   document.getElementById("export-join-rear").disabled = !hasRear;
   document.getElementById("export-pip-front").disabled = !hasPair;
   document.getElementById("export-pip-rear").disabled = !hasPair;
+  // Third-camera (tele / interior) actions: the whole button group
+  // stays hidden unless that camera appears in the day's data, so
+  // 2-camera setups see the original action bar unchanged.
+  const camGroup = (cam, present, dl, join, pip, pipOk) => {
+    const group = document.getElementById(`actions-${cam}`);
+    if (!group) return;
+    group.hidden = !present;
+    if (!present) return;
+    document.getElementById(dl).disabled = !present;
+    document.getElementById(join).disabled = !present;
+    document.getElementById(pip).disabled = !pipOk;
+  };
+  camGroup(
+    "tele", teles > 0,
+    "dl-orig-tele", "export-join-tele", "export-pip-tele",
+    frontTele > 0,
+  );
+  camGroup(
+    "interior", interiors > 0,
+    "dl-orig-interior", "export-join-interior",
+    "export-pip-interior", frontInterior > 0,
+  );
   document.getElementById("clear-selection").disabled = n === 0;
 }
 
@@ -1116,7 +1149,8 @@ function clearSelection() {
 }
 
 function downloadOriginals(slot) {
-  // slot: "front" | "rear". Download each selected original clip
+  // slot: "front" | "rear" | "tele" | "interior". Download each
+  // selected original clip
   // as its own file (no ZIP). The clip stream endpoint sends
   // Content-Disposition: attachment with the dashcam basename, so
   // a same-origin anchor click triggers a named download. Stagger
@@ -1126,8 +1160,7 @@ function downloadOriginals(slot) {
   // doesn't take ages to fire.
   const ids = [];
   for (const v of state.archiveSelected.values()) {
-    if (slot === "front" && v.front) ids.push(v.front);
-    else if (slot === "rear" && v.rear) ids.push(v.rear);
+    if (v[slot]) ids.push(v[slot]);
   }
   if (!ids.length) return;
   ids.forEach((id, i) => {
@@ -1148,9 +1181,18 @@ async function submitExport(type) {
   for (const v of state.archiveSelected.values()) {
     if (type === "join_front" && v.front) ids.push(v.front);
     else if (type === "join_rear" && v.rear) ids.push(v.rear);
-    else if (type === "pip" || type === "pip_rear") {
+    else if (type === "join_tele" && v.tele) ids.push(v.tele);
+    else if (type === "join_interior" && v.interior) {
+      ids.push(v.interior);
+    } else if (type === "pip" || type === "pip_rear") {
       if (v.front) ids.push(v.front);
       if (v.rear) ids.push(v.rear);
+    } else if (type === "pip_tele") {
+      if (v.front) ids.push(v.front);
+      if (v.tele) ids.push(v.tele);
+    } else if (type === "pip_interior") {
+      if (v.front) ids.push(v.front);
+      if (v.interior) ids.push(v.interior);
     }
   }
   if (!ids.length) return;
@@ -1224,6 +1266,18 @@ document.getElementById("export-pip-front")
   .addEventListener("click", () => submitExport("pip"));
 document.getElementById("export-pip-rear")
   .addEventListener("click", () => submitExport("pip_rear"));
+document.getElementById("dl-orig-tele")
+  .addEventListener("click", () => downloadOriginals("tele"));
+document.getElementById("export-join-tele")
+  .addEventListener("click", () => submitExport("join_tele"));
+document.getElementById("export-pip-tele")
+  .addEventListener("click", () => submitExport("pip_tele"));
+document.getElementById("dl-orig-interior")
+  .addEventListener("click", () => downloadOriginals("interior"));
+document.getElementById("export-join-interior")
+  .addEventListener("click", () => submitExport("join_interior"));
+document.getElementById("export-pip-interior")
+  .addEventListener("click", () => submitExport("pip_interior"));
 document.getElementById("clear-selection")
   .addEventListener("click", clearSelection);
 
@@ -1316,8 +1370,12 @@ function toast(message, opts = {}) {
 const EXPORT_TYPE_LABELS = {
   join_front: "Join Front",
   join_rear: "Join Rear",
+  join_tele: "Join Tele",
+  join_interior: "Join Interior",
   pip: "PiP Fr",
   pip_rear: "PiP Rf",
+  pip_tele: "PiP Tf",
+  pip_interior: "PiP If",
   timeline: "Timeline",
 };
 
@@ -1545,20 +1603,27 @@ function renderExportJobs(jobs) {
 
 // ---------- Video modal + nav ----------
 
+// Camera letters in modal cycle order. Only F+R plus one of T
+// (telephoto) or I (interior) exist on any single device, but
+// keeping all four here costs nothing — absent cameras have empty
+// timelines and the cycle skips them.
+const MODAL_CAMERAS = ["F", "R", "T", "I"];
+
 function buildCameraTimelines(scopeEl) {
   const root = scopeEl || document.getElementById("view-archive");
-  const F = [], R = [];
+  const timelines = { F: [], R: [], T: [], I: [] };
   root.querySelectorAll(".thumb[data-clip-id]").forEach((el) => {
     const entry = {
       id: Number(el.dataset.clipId),
       ts: Number(el.dataset.ts),
       el,
     };
-    (el.dataset.camera === "F" ? F : R).push(entry);
+    (timelines[el.dataset.camera] || timelines.F).push(entry);
   });
-  F.sort((a, b) => a.ts - b.ts);
-  R.sort((a, b) => a.ts - b.ts);
-  return { F, R };
+  for (const cam of MODAL_CAMERAS) {
+    timelines[cam].sort((a, b) => a.ts - b.ts);
+  }
+  return timelines;
 }
 
 function openVideo(clipId, camera, sourceEl, opts = {}) {
@@ -1613,13 +1678,30 @@ function updateModalNav() {
   prev.disabled = i <= 0;
   next.disabled = i < 0 || i >= list.length - 1;
 
-  const other = mc.camera === "F" ? "R" : "F";
   const curr = list[i];
-  const match = curr
-    ? mc.timelines[other].find((e) => e.ts === curr.ts)
-    : null;
-  toggle.disabled = !match;
-  toggle.textContent = other === "R" ? "Rear view" : "Front view";
+  const next_ = curr ? nextCameraClip(mc, curr.ts) : null;
+  toggle.disabled = !next_;
+  if (next_) {
+    toggle.textContent = `${CAMERA_VIEW_LABELS[next_.camera]} view`;
+  }
+}
+
+const CAMERA_VIEW_LABELS = {
+  F: "Front", R: "Rear", T: "Tele", I: "Interior",
+};
+
+// The next camera (cycling F→R→T→I→F) that has a clip at ``ts``,
+// or null when the current camera is the only one — the cycle
+// skips cameras with no same-timestamp clip, so a 2-cam day
+// behaves exactly like the old binary toggle.
+function nextCameraClip(mc, ts) {
+  const start = MODAL_CAMERAS.indexOf(mc.camera);
+  for (let step = 1; step < MODAL_CAMERAS.length; step++) {
+    const cam = MODAL_CAMERAS[(start + step) % MODAL_CAMERAS.length];
+    const match = mc.timelines[cam].find((e) => e.ts === ts);
+    if (match) return { camera: cam, clip: match };
+  }
+  return null;
 }
 
 function stepVideo(delta) {
@@ -1635,17 +1717,16 @@ function stepVideo(delta) {
 function toggleVideoCamera() {
   const mc = state.modalClip;
   if (!mc) return;
-  const other = mc.camera === "F" ? "R" : "F";
   const curr = mc.timelines[mc.camera].find((e) => e.id === mc.id);
   if (!curr) return;
-  const match = mc.timelines[other].find((e) => e.ts === curr.ts);
-  if (!match) return;
+  const next = nextCameraClip(mc, curr.ts);
+  if (!next) return;
   // Preserve current playback position and pause state so the
   // other camera picks up where this one was.
   const video = document.querySelector("#modal-body video");
   const seekTo = video ? video.currentTime : 0;
   const autoplay = video ? !video.paused : true;
-  openVideo(match.id, other, match.el, { seekTo, autoplay });
+  openVideo(next.clip.id, next.camera, next.clip.el, { seekTo, autoplay });
 }
 
 function closeModal() {
@@ -1795,7 +1876,12 @@ function renderQueue() {
 function renderKindBadge(it) {
   const cam = it.kind_camera || it.camera || "";
   const evt = it.kind_event || "";
-  const camLabel = cam === "F" ? "Front" : cam === "R" ? "Rear" : "?";
+  const camLabel =
+    cam === "F" ? "Front"
+    : cam === "R" ? "Rear"
+    : cam === "T" ? "Tele"
+    : cam === "I" ? "Interior"
+    : "?";
   const parts = [`<span class="kind-badge kind-${escHtml(cam)}">${camLabel}</span>`];
   if (evt === "parking") {
     parts.push(`<span class="kind-badge kind-parking">Parking</span>`);

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -126,8 +126,9 @@
                     title="Picture-in-picture, rear main">Rf</button>
           </div>
           <!-- Third-camera (telephoto / interior) groups: hidden
-               unless the selection's day contains that camera, so
-               2-camera setups see the original bar unchanged. -->
+               until the selection contains a clip from that
+               camera, so 2-camera setups see the original bar
+               unchanged. -->
           <div class="action-group" id="actions-tele" hidden>
             <span class="action-label">Tele:</span>
             <button type="button" id="dl-orig-tele"

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -125,6 +125,33 @@
                     aria-label="Picture-in-picture, rear main"
                     title="Picture-in-picture, rear main">Rf</button>
           </div>
+          <!-- Third-camera (telephoto / interior) groups: hidden
+               unless the selection's day contains that camera, so
+               2-camera setups see the original bar unchanged. -->
+          <div class="action-group" id="actions-tele" hidden>
+            <span class="action-label">Tele:</span>
+            <button type="button" id="dl-orig-tele"
+                    aria-label="Download selected telephoto originals"
+                    title="Download selected telephoto originals">T</button>
+            <button type="button" id="export-join-tele"
+                    aria-label="Join selected telephoto clips"
+                    title="Join selected telephoto clips">Join</button>
+            <button type="button" id="export-pip-tele"
+                    aria-label="Picture-in-picture, telephoto main"
+                    title="Picture-in-picture, telephoto main">Tf</button>
+          </div>
+          <div class="action-group" id="actions-interior" hidden>
+            <span class="action-label">Interior:</span>
+            <button type="button" id="dl-orig-interior"
+                    aria-label="Download selected interior originals"
+                    title="Download selected interior originals">I</button>
+            <button type="button" id="export-join-interior"
+                    aria-label="Join selected interior clips"
+                    title="Join selected interior clips">Join</button>
+            <button type="button" id="export-pip-interior"
+                    aria-label="Picture-in-picture, interior main"
+                    title="Picture-in-picture, interior main">If</button>
+          </div>
           <button type="button" id="clear-selection">Clear selected clips</button>
         </div>
         <div id="exports-panel" class="exports-panel" hidden>
@@ -269,7 +296,7 @@
         <div id="modal-body"></div>
         <div class="modal-nav">
           <button type="button" id="modal-prev" title="Previous clip (←)">← Prev</button>
-          <button type="button" id="modal-toggle" title="Switch camera (F)">Rear view</button>
+          <button type="button" id="modal-toggle" title="Cycle camera (F)">Rear view</button>
           <button type="button" id="modal-next" title="Next clip (→)">Next →</button>
           <label class="modal-autoplay"
                  title="Play the next clip automatically when this one ends">
@@ -309,8 +336,8 @@
               <line x1="12" y1="3" x2="12" y2="15"/>
             </svg>
             <span class="dropzone-title">Drag a folder here, or click to browse</span>
-            <span class="dropzone-hint">Front &amp; rear <code>.MP4</code> files are
-              recognised automatically</span>
+            <span class="dropzone-hint">Front, rear, telephoto &amp; interior
+              <code>.MP4</code> files are recognised automatically</span>
           </label>
           <div id="import-upload-manifest" class="manifest"></div>
           <button id="import-upload-go" class="btn primary" disabled>Import</button>

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -575,7 +575,12 @@ main {
 .clip-pair .time label { flex: 1 1 auto; }
 .clip-pair .time .kind-badge { font-weight: 500; }
 .clip-pair .thumbs {
-  display: grid; grid-template-columns: 1fr 1fr; gap: 4px;
+  /* auto-fit yields 2 equal columns for F+R days and 3 for
+     3-camera (F+R+T/I) days; the 80px floor keeps thumbs from
+     collapsing to icon size on narrow viewports. */
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+  gap: 4px;
   margin: 6px 0;
 }
 .clip-pair img {
@@ -946,6 +951,14 @@ main {
 .kind-badge.kind-R {
   color: oklch(0.76 0.10 200);
   border-color: oklch(0.50 0.08 200);
+}
+/* Third camera (telephoto or interior — never both on one device)
+ * shares a magenta clear of ok-green 145, rear-teal 200, accent,
+ * warn and err hues. */
+.kind-badge.kind-T,
+.kind-badge.kind-I {
+  color: oklch(0.76 0.11 315);
+  border-color: oklch(0.52 0.09 315);
 }
 .kind-badge.kind-parking { color: var(--warn); border-color: var(--warn); }
 .kind-badge.kind-event { color: var(--err-text); border-color: var(--err); }


### PR DESCRIPTION
Awesome work here! I'm glad I didn't move forward with my ideas before, as you've done exactly (or better) what I had planned!

I have 3 camera version, so here's my suggestion to add support for it. It takes into account if 3rd camera is cabin cam or telephoto. Tried to follow your way of doing it and to not clutter the UI with all variations which third camera could bring.

---

A few details to complete the picture:

- The third camera is the filename's trailing letter: `T` (telephoto, e.g. A329) or `I` (interior/cabin, e.g. A139 / A229 3CH). Before this, those files downloaded fine but the scanner glob skipped them and the archive day-pairer filed any non-F camera under "rear" — a T/I clip silently overwrote the real rear slot.
- This completes the interior pre-wiring you already had in `naming.py` (`"I": "interior"`) and extends the same to telephoto. Timeline needed no changes — channels are data-driven, so the third track just appears (the segment-channel validator now accepts `tele`; `interior` was already there).
- New exports: `join_tele` / `join_interior` and `pip_tele` / `pip_interior` (third camera fullscreen + front inset). Front stays ffmpeg input 0 in every PiP variant so the mic audio is kept; existing `pip` / `pip_rear` invocations are bit-identical.
- UI: the third thumb and its action buttons only show up when the data actually has that camera — 2-camera setups see a pixel-identical UI. The clip modal's `F` key now cycles through whatever cameras exist at that timestamp.
- Tests cover parsing (T/PT/ET, I/PI/EI), pair-slot dispatch, export-type validation, PiP filter graphs, importer classification and timeline channel ordering. Validated live on my A329 (241 telephoto clips indexed + exports verified) and with real interior footage from my old cabin-cam setup.

Deliberately matched your existing hardcoded-letter style rather than introducing a camera registry, to keep the diff small — happy to do that refactor as a follow-up if you'd prefer it.